### PR TITLE
Support disabling vaulted PayPal accounts

### DIFF
--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -37,7 +37,7 @@
 - (BOOL)shouldDisplayVaultedNonceForRequest:(BTDropInRequest *)request config:(BTConfiguration *)configuration {
     if ([self isKindOfClass:BTCardNonce.class] && (request.cardDisabled || configuration.supportedCardTypes.count == 0)) {
         return NO;
-    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || !configuration.isPayPalEnabled)) {
+    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || request.vaultedPaypalAccountsDisabled || !configuration.isPayPalEnabled)) {
         return NO;
     } else if ([self isKindOfClass:BTVenmoAccountNonce.class] && (request.venmoDisabled || !configuration.isVenmoEnabled)) {
         return NO;

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -31,6 +31,7 @@
     request.vaultManager = self.vaultManager;
     request.vaultCard = self.vaultCard;
     request.allowVaultCardOverride = self.allowVaultCardOverride;
+    request.vaultedPaypalAccountsDisabled = self.vaultedPaypalAccountsDisabled;
     return request;
 }
 

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -40,6 +40,9 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false. Set to true to hide the Card option even if enabled for your account.
 @property (nonatomic, assign) BOOL cardDisabled;
 
+/// Defaults to false. Set to true to hide vaulted PayPal accounts even if enabled for your account.
+@property (nonatomic, assign) BOOL vaultedPaypalAccountsDisabled;
+
 /// Optional: Enable 3DS verification and specify options and additional information.
 ///
 /// Note: To encourage 3DS 2.0 flows, set `billingAddress`, `amount`, `email`, `mobilePhone` for best results.

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -51,6 +51,7 @@
     originalRequest.vaultManager = YES;
     originalRequest.vaultCard = NO;
     originalRequest.allowVaultCardOverride = YES;
+    originalRequest.vaultedPaypalAccountsDisabled = YES;
 
     BTDropInRequest *copiedRequest = [originalRequest copy];
     
@@ -65,6 +66,7 @@
     XCTAssertEqual(originalRequest.vaultManager, copiedRequest.vaultManager);
     XCTAssertEqual(originalRequest.vaultCard, copiedRequest.vaultCard);
     XCTAssertEqual(originalRequest.allowVaultCardOverride, copiedRequest.allowVaultCardOverride);
+    XCTAssertEqual(originalRequest.vaultedPaypalAccountsDisabled, copiedRequest.vaultedPaypalAccountsDisabled);
 
     XCTAssertEqual(originalRequest.threeDSecureRequest, copiedRequest.threeDSecureRequest);
     XCTAssertEqual(BTThreeDSecureVersion2, copiedRequest.threeDSecureRequest.versionRequested);


### PR DESCRIPTION
### Summary of changes

This PR adds support to disable vaulted PayPal accounts (which are then not shown in the payment selection modal) without disabling PayPal as a payment method. To achieve this, the following changes are proposed:

- Added a dedicated boolean configuration property to `BTDropInRequest` named `vaultedPaypalAccountsDisabled`, defaulting to `false`.
- Add a check on the value of that property to `BTPaymentMethodNonce`'s `shouldDisplayVaultedNonceForRequest:config:`. If the receiver is an instance of `BTPayPalAccountNonce` and the request's`vaultedPaypalAccountsDisabled` property is true, the return value is `NO`.  
