### PR TITLE
Remove patch from Braintree SDK version requirement

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.6.1"
-  s.dependency "Braintree/Card", "~> 5.6.1"
-  s.dependency "Braintree/Core", "~> 5.6.1"
-  s.dependency "Braintree/UnionPay", "~> 5.6.1"
-  s.dependency "Braintree/PayPal", "~> 5.6.1"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.6.1"
-  s.dependency "Braintree/Venmo", "~> 5.6.1"
+  s.dependency "Braintree/ApplePay", "~> 5.7"
+  s.dependency "Braintree/Card", "~> 5.7"
+  s.dependency "Braintree/Core", "~> 5.7"
+  s.dependency "Braintree/UnionPay", "~> 5.7"
+  s.dependency "Braintree/PayPal", "~> 5.7"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.7"
+  s.dependency "Braintree/Venmo", "~> 5.7"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 


### PR DESCRIPTION
### Summary of changes

This PR updates the Drop-In's podspec version requirement for the Braintree SDK from `~> 5.6.1` to `~> 5.7`, as the upstream podspec involuntarily prevents integrating version 9.4.0 of the Drop-In SDK with Braintree SDK versions from 5.7 onwards.