### PR TITLE
Apply Subito customizations to version 9.7.0

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		425B83982347D3990015D1A4 /* BTUIKAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */; };
 		42D53E782614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D53E772614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift */; };
 		42EA70662616682800B7E626 /* BTDropInResult_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 42EA70652616682800B7E626 /* BTDropInResult_Internal.h */; };
+		4C2901B02743FC0700505D46 /* SBTAddCardButtonFormField.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4C2901B22743FC1B00505D46 /* SBTAddCardButtonFormField.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */; };
 		8005E86125BB32A6003EC2AC /* MockVenmoDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8005E86025BB32A6003EC2AC /* MockVenmoDriver.swift */; };
 		8005E86625BB34B5003EC2AC /* MockAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8005E86525BB34B5003EC2AC /* MockAPIClient.swift */; };
 		8038FA13269789ED007BE751 /* MockPPDataCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8038FA12269789ED007BE751 /* MockPPDataCollector.swift */; };
@@ -233,6 +235,8 @@
 		42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		42D53E772614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUIKCardholderNameFormFieldTests.swift; sourceTree = "<group>"; };
 		42EA70652616682800B7E626 /* BTDropInResult_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTDropInResult_Internal.h; sourceTree = "<group>"; };
+		4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SBTAddCardButtonFormField.h; sourceTree = "<group>"; };
+		4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SBTAddCardButtonFormField.m; sourceTree = "<group>"; };
 		53E78BDC22248A29000388D3 /* BTUIKHipercardVectorArtView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTUIKHipercardVectorArtView.h; sourceTree = "<group>"; };
 		53E78BDF22248A29000388D3 /* BTUIKHipercardVectorArtView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTUIKHipercardVectorArtView.m; sourceTree = "<group>"; };
 		53E78BE422248BC3000388D3 /* BTUIKLargeHiperVectorArtView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTUIKLargeHiperVectorArtView.h; sourceTree = "<group>"; };
@@ -484,6 +488,8 @@
 				D6C2F3332239917F00DFF7E5 /* BTUIKSwitchFormField.m */,
 				A52901161D8903A600032220 /* BTUIKTextField.h */,
 				A52900E11D8903A600032220 /* BTUIKTextField.m */,
+				4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */,
+				4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -730,6 +736,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4234907A260BA5800006D38B /* BTUIKInputAccessoryToolbar.h in Headers */,
+				4C2901B02743FC0700505D46 /* SBTAddCardButtonFormField.h in Headers */,
 				42349098260BA6000006D38B /* BTDropInLocalization.h in Headers */,
 				42349062260BA5800006D38B /* BTUIKSecurityCodeFormField.h in Headers */,
 				8068E589256D9C68002904E6 /* BTUIKBarButtonItem_Internal_Declaration.h in Headers */,
@@ -1027,6 +1034,7 @@
 				80BBF006260BC77E005D646D /* BTUIKJCBVectorArtView.m in Sources */,
 				A56C41901D833568000DFFAB /* BTDropInController.m in Sources */,
 				80BBEFAF260BC75C005D646D /* BTUIKLargeVisaVectorArtView.m in Sources */,
+				4C2901B22743FC1B00505D46 /* SBTAddCardButtonFormField.m in Sources */,
 				A56C41A21D8335BB000DFFAB /* BTEnrollmentVerificationViewController.m in Sources */,
 				4234905E260BA5800006D38B /* BTUIKPostalCodeFormField.m in Sources */,
 				42349006260BA3730006D38B /* BTUIKCardExpiryFormat.m in Sources */,

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -375,7 +375,8 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
-        XCTAssertFalse(app.buttons["Add Card"].isEnabled)
+        app.buttons["Add Card"].forceTapElement()
+        waitForElementToBeHittable(app.staticTexts["Attenzione"])
     }
 
     func testDropIn_cardholderNameRequired_canAddCardWithName() {

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -327,6 +327,7 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         [UIView animateWithDuration:0.15 delay:0.0 options:UIViewAnimationOptionAllowAnimatedContent|UIViewAnimationOptionBeginFromCurrentState animations:^{
             self.cardNumberHeader.hidden = !collapsed;
+            self.cardNumberFooter.hidden = !collapsed;
             self.cardholderNameField.hidden = (self.dropInRequest.cardholderNameSetting == BTFormFieldDisabled) || collapsed;
             self.expirationDateField.hidden = collapsed;
             self.securityCodeField.hidden = ![self.requiredFields containsObject:self.securityCodeField] || collapsed;

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -37,7 +37,7 @@
 - (BOOL)shouldDisplayVaultedNonceForRequest:(BTDropInRequest *)request config:(BTConfiguration *)configuration {
     if ([self isKindOfClass:BTCardNonce.class] && (request.cardDisabled || configuration.supportedCardTypes.count == 0)) {
         return NO;
-    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || !configuration.isPayPalEnabled)) {
+    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || request.vaultedPaypalAccountsDisabled || !configuration.isPayPalEnabled)) {
         return NO;
     } else if ([self isKindOfClass:BTVenmoAccountNonce.class] && (request.venmoDisabled || !configuration.isVenmoEnabled)) {
         return NO;

--- a/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.h
+++ b/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.h
@@ -1,0 +1,22 @@
+// Copyright © 2019 Subito.it. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SBTAddCardButtonFormField;
+
+@protocol SBTAddCardButtonFormFieldDelegate <NSObject>
+
+- (void)addCardFieldTapped:(SBTAddCardButtonFormField *)field;
+
+@end
+
+@interface SBTAddCardButtonFormField : UIView
+
+@property (nonatomic, weak) id<SBTAddCardButtonFormFieldDelegate> delegate;
+@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.m
+++ b/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.m
@@ -1,0 +1,82 @@
+// Copyright © 2019 Subito.it. All rights reserved.
+
+#import "SBTAddCardButtonFormField.h"
+#import "BTDropInLocalization_Internal.h"
+#import "BTUIKAppearance.h"
+
+@interface UIImage (Color)
+
++ (UIImage *)sbt_resizableImageWithColor:(UIColor *)color cornerRadius:(CGFloat)radius;
+
+@end
+
+@implementation UIImage (Color)
+
++ (UIImage *)sbt_resizableImageWithColor:(UIColor *)color cornerRadius:(CGFloat)radius {
+    CGSize size = CGSizeMake((radius * 2.0) + 1.0, (radius * 2.0) + 1.0);
+    CGRect rect = CGRectMake(0.0, 0.0, size.width, size.height);
+    
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+        CGContextRef contextRef = context.CGContext;
+        CGContextSetFillColorWithColor(contextRef, color.CGColor);
+        CGContextAddPath(contextRef, [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:radius].CGPath);
+        CGContextFillPath(contextRef);
+    }];
+    
+    UIEdgeInsets capInsets = UIEdgeInsetsMake(radius, radius, radius, radius);
+    return [image resizableImageWithCapInsets:capInsets];
+}
+
+@end
+
+@interface SBTAddCardButtonFormField ()
+
+@property (nonatomic, strong) UIButton *addButton;
+
+@end
+
+@implementation SBTAddCardButtonFormField
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        UIImage *normalImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.tintColor cornerRadius:4.0];
+        UIImage *disabledImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.disabledColor cornerRadius:4.0];
+        UIImage *highlightedImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.highlightedTintColor cornerRadius:4.0];
+        
+        _addButton = [UIButton new];
+        _addButton.translatesAutoresizingMaskIntoConstraints = NO;
+        _addButton.titleLabel.font = [BTUIKAppearance.sharedInstance.headlineFont fontWithSize:UIFont.labelFontSize];
+        [_addButton setBackgroundImage:normalImage forState:UIControlStateNormal];
+        [_addButton setBackgroundImage:disabledImage forState:UIControlStateDisabled];
+        [_addButton setBackgroundImage:highlightedImage forState:UIControlStateHighlighted];
+        [_addButton setTitle:BTDropInLocalizedString(ADD_CARD_ACTION) forState:UIControlStateNormal];
+        [_addButton addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
+        
+        [self addSubview:_addButton];
+        
+        NSLayoutConstraint *heightConstraint = [_addButton.heightAnchor constraintEqualToConstant:44.0];
+        heightConstraint.priority = UILayoutPriorityDefaultHigh;
+        
+        [NSLayoutConstraint activateConstraints:@[
+            heightConstraint,
+            [_addButton.topAnchor constraintEqualToAnchor:self.topAnchor],
+            [_addButton.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+            [_addButton.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor],
+            [_addButton.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor]
+        ]];
+    }
+    return self;
+}
+
+- (void)setEnabled:(BOOL)enabled {
+    _enabled = enabled;
+    [self.addButton setEnabled:enabled];
+}
+
+- (void)tapped {
+    [self.delegate addCardFieldTapped:self];
+}
+
+@end
+

--- a/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
@@ -27,7 +27,7 @@
 
         self.label = [[UILabel alloc] init];
         [BTUIKAppearance styleLabelPrimary:self.label];
-        self.label.numberOfLines = 2;
+        self.label.numberOfLines = 0;
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
         [self.labelContainer addArrangedSubview:self.label];
 

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -31,6 +31,7 @@
     request.vaultManager = self.vaultManager;
     request.vaultCard = self.vaultCard;
     request.allowVaultCardOverride = self.allowVaultCardOverride;
+    request.vaultedPaypalAccountsDisabled = self.vaultedPaypalAccountsDisabled;
     return request;
 }
 

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -40,6 +40,9 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false. Set to true to hide the Card option even if enabled for your account.
 @property (nonatomic, assign) BOOL cardDisabled;
 
+/// Defaults to false. Set to true to hide vaulted PayPal accounts even if enabled for your account.
+@property (nonatomic, assign) BOOL vaultedPaypalAccountsDisabled;
+
 /// Optional: Enable 3DS verification and specify options and additional information.
 ///
 /// Note: To encourage 3DS 2.0 flows, set `billingAddress`, `amount`, `email`, `mobilePhone` for best results.

--- a/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
+++ b/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
@@ -39,7 +39,7 @@
 "MONTH_LABEL"                               = "Mese";
 
 "OTHER_LABEL"                               = "Altro";
-"CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito";
+"CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito (bancomat)";
 "RECENT_LABEL"                              = "Recenti";
 "SELECT_PAYMENT_LABEL"                      = "Metodo di pagamento";
 

--- a/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
+++ b/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
@@ -41,7 +41,7 @@
 "OTHER_LABEL"                               = "Altro";
 "CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito";
 "RECENT_LABEL"                              = "Recenti";
-"SELECT_PAYMENT_LABEL"                      = "Seleziona metodo di pagamento";
+"SELECT_PAYMENT_LABEL"                      = "Metodo di pagamento";
 
 "CONFIRM_ENROLLMENT_LABEL"                  = "Conferma registrazione";
 "CONFIRM_ACTION"                            = "Conferma";

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -51,6 +51,7 @@
     originalRequest.vaultManager = YES;
     originalRequest.vaultCard = NO;
     originalRequest.allowVaultCardOverride = YES;
+    originalRequest.vaultedPaypalAccountsDisabled = YES;
 
     BTDropInRequest *copiedRequest = [originalRequest copy];
     
@@ -65,6 +66,7 @@
     XCTAssertEqual(originalRequest.vaultManager, copiedRequest.vaultManager);
     XCTAssertEqual(originalRequest.vaultCard, copiedRequest.vaultCard);
     XCTAssertEqual(originalRequest.allowVaultCardOverride, copiedRequest.allowVaultCardOverride);
+    XCTAssertEqual(originalRequest.vaultedPaypalAccountsDisabled, copiedRequest.vaultedPaypalAccountsDisabled);
 
     XCTAssertEqual(originalRequest.threeDSecureRequest, copiedRequest.threeDSecureRequest);
     XCTAssertEqual(BTThreeDSecureVersion2, copiedRequest.threeDSecureRequest.versionRequested);


### PR DESCRIPTION
### Summary of changes

This PR applies the Subito-specific customizations introduced by https://github.com/Subito-it/braintree-ios-drop-in/pull/3 and https://github.com/Subito-it/braintree-ios-drop-in/pull/4 to version [`9.7.0`](https://github.com/braintree/braintree-ios-drop-in/releases/tag/9.7.0) of the Drop-In SDK.

All customizations are carried over without changes.
