### PR TITLE
Apply Subito customizations to version 9.12.0

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		425B83982347D3990015D1A4 /* BTUIKAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */; };
 		42D53E782614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D53E772614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift */; };
 		42EA70662616682800B7E626 /* BTDropInResult_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 42EA70652616682800B7E626 /* BTDropInResult_Internal.h */; };
+		4C2901B02743FC0700505D46 /* SBTAddCardButtonFormField.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4C2901B22743FC1B00505D46 /* SBTAddCardButtonFormField.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */; };
 		8005E86125BB32A6003EC2AC /* MockVenmoDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8005E86025BB32A6003EC2AC /* MockVenmoDriver.swift */; };
 		8005E86625BB34B5003EC2AC /* MockAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8005E86525BB34B5003EC2AC /* MockAPIClient.swift */; };
 		8038FA13269789ED007BE751 /* MockPPDataCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8038FA12269789ED007BE751 /* MockPPDataCollector.swift */; };
@@ -234,6 +236,8 @@
 		42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		42D53E772614DA3600D19615 /* BTUIKCardholderNameFormFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUIKCardholderNameFormFieldTests.swift; sourceTree = "<group>"; };
 		42EA70652616682800B7E626 /* BTDropInResult_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTDropInResult_Internal.h; sourceTree = "<group>"; };
+		4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SBTAddCardButtonFormField.h; sourceTree = "<group>"; };
+		4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SBTAddCardButtonFormField.m; sourceTree = "<group>"; };
 		53E78BDC22248A29000388D3 /* BTUIKHipercardVectorArtView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTUIKHipercardVectorArtView.h; sourceTree = "<group>"; };
 		53E78BDF22248A29000388D3 /* BTUIKHipercardVectorArtView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTUIKHipercardVectorArtView.m; sourceTree = "<group>"; };
 		53E78BE422248BC3000388D3 /* BTUIKLargeHiperVectorArtView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTUIKLargeHiperVectorArtView.h; sourceTree = "<group>"; };
@@ -486,6 +490,8 @@
 				D6C2F3332239917F00DFF7E5 /* BTUIKSwitchFormField.m */,
 				A52901161D8903A600032220 /* BTUIKTextField.h */,
 				A52900E11D8903A600032220 /* BTUIKTextField.m */,
+				4C2901AF2743FC0700505D46 /* SBTAddCardButtonFormField.h */,
+				4C2901B12743FC1B00505D46 /* SBTAddCardButtonFormField.m */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -733,6 +739,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4234907A260BA5800006D38B /* BTUIKInputAccessoryToolbar.h in Headers */,
+				4C2901B02743FC0700505D46 /* SBTAddCardButtonFormField.h in Headers */,
 				42349098260BA6000006D38B /* BTDropInLocalization.h in Headers */,
 				42349062260BA5800006D38B /* BTUIKSecurityCodeFormField.h in Headers */,
 				8068E589256D9C68002904E6 /* BTUIKBarButtonItem_Internal_Declaration.h in Headers */,
@@ -1031,6 +1038,7 @@
 				80BBF006260BC77E005D646D /* BTUIKJCBVectorArtView.m in Sources */,
 				A56C41901D833568000DFFAB /* BTDropInController.m in Sources */,
 				80BBEFAF260BC75C005D646D /* BTUIKLargeVisaVectorArtView.m in Sources */,
+				4C2901B22743FC1B00505D46 /* SBTAddCardButtonFormField.m in Sources */,
 				A56C41A21D8335BB000DFFAB /* BTEnrollmentVerificationViewController.m in Sources */,
 				4234905E260BA5800006D38B /* BTUIKPostalCodeFormField.m in Sources */,
 				42349006260BA3730006D38B /* BTUIKCardExpiryFormat.m in Sources */,

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -429,7 +429,8 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
-        XCTAssertFalse(app.buttons["Add Card"].isEnabled)
+        app.buttons["Add Card"].forceTapElement()
+        waitForElementToBeHittable(app.staticTexts["Attenzione"])
     }
 
     func testDropIn_cardholderNameRequired_canAddCardWithName() {

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -235,6 +235,9 @@
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.cardholderNameField size: [BTUIKAppearance verticalFormSpace]];
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.mobileCountryCodeField size: [BTUIKAppearance verticalFormSpace]];
 
+    // Spacing between add card field and privacy policy label
+    [self.stackView setCustomSpacing:[BTUIKAppearance verticalFormSpaceTight] afterView:self.addCardField];
+
     self.cardNumberFooter = [BTDropInUIUtilities newStackView];
     self.cardNumberFooter.layoutMargins = UIEdgeInsetsMake(0, [BTUIKAppearance verticalFormSpace], 0, [BTUIKAppearance verticalFormSpace]);
     self.cardNumberFooter.layoutMarginsRelativeArrangement = true;

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -11,6 +11,7 @@
 #import "BTUIKCardListLabel.h"
 #import "BTUIKViewUtil.h"
 #import "BTDropInLocalization_Internal.h"
+#import "SBTAddCardButtonFormField.h"
 
 #if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
@@ -24,11 +25,12 @@
 #import <BraintreeUnionPay/BraintreeUnionPay.h>
 #endif
 
-@interface BTCardFormViewController ()
+@interface BTCardFormViewController () <SBTAddCardButtonFormFieldDelegate>
 
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIView *scrollViewContentWrapper;
 @property (nonatomic, strong) UIStackView *stackView;
+@property (nonatomic, strong) SBTAddCardButtonFormField *addCardField;
 @property (nonatomic, strong, readwrite) BTUIKCardNumberFormField *cardNumberField;
 @property (nonatomic, strong, readwrite) BTUIKCardholderNameFormField *cardholderNameField;
 @property (nonatomic, strong, readwrite) BTUIKExpiryFormField *expirationDateField;
@@ -186,6 +188,8 @@
     self.mobileCountryCodeField.delegate = self;
     self.mobilePhoneField = [[BTUIKMobileNumberFormField alloc] init];
     self.mobilePhoneField.delegate = self;
+    self.addCardField = [[SBTAddCardButtonFormField alloc] init];
+    self.addCardField.delegate = self;
     
     self.cardNumberHeader = [BTDropInUIUtilities newStackView];
     self.cardNumberHeader.layoutMargins = UIEdgeInsetsMake(0, [BTUIKAppearance verticalFormSpace], 0, [BTUIKAppearance verticalFormSpace]);
@@ -199,7 +203,7 @@
     [BTDropInUIUtilities addSpacerToStackView:self.cardNumberHeader beforeView:cardNumberHeaderLabel size: [BTUIKAppearance verticalFormSpace]];
     [self.stackView addArrangedSubview:self.cardNumberHeader];
 
-    self.formFields = @[self.cardNumberField, self.cardholderNameField, self.expirationDateField, self.securityCodeField, self.postalCodeField, self.mobileCountryCodeField, self.mobilePhoneField];
+    self.formFields = @[self.cardNumberField, self.cardholderNameField, self.expirationDateField, self.securityCodeField, self.postalCodeField, self.mobileCountryCodeField, self.mobilePhoneField, self.addCardField];
 
     for (BTUIKFormField *formField in self.formFields) {
         [self.stackView addArrangedSubview:formField];
@@ -213,6 +217,7 @@
     self.postalCodeField.hidden = YES;
     self.mobileCountryCodeField.hidden = YES;
     self.mobilePhoneField.hidden = YES;
+    self.addCardField.hidden = YES;
 
     // Privacy Policy label
     UILabel *privacyPolicyLabel = [[UILabel alloc] init];
@@ -356,6 +361,7 @@
             self.mobilePhoneField.hidden = ![self.requiredFields containsObject:self.mobilePhoneField] || collapsed;
             self.enrollmentFooter.hidden = self.mobilePhoneField.hidden;
             self.shouldVaultCardSwitchField.hidden = ![self shouldDisplaySaveCardToggle] || collapsed;
+            self.addCardField.hidden = self.collapsed;
             [self updateFormBorders];
         } completion:^(__unused BOOL finished) {
             self.cardNumberFooter.hidden = !collapsed;
@@ -368,9 +374,9 @@
             self.mobilePhoneField.hidden = ![self.requiredFields containsObject:self.mobilePhoneField] || collapsed;
             self.enrollmentFooter.hidden = self.mobilePhoneField.hidden;
             self.shouldVaultCardSwitchField.hidden = ![self shouldDisplaySaveCardToggle] || collapsed;
+            self.addCardField.hidden = self.collapsed;
             
             [self updateFormBorders];
-            [self updateSubmitButton];
         }];
     });
 }
@@ -383,15 +389,11 @@
 
 - (void)resetForm {
     self.navigationItem.leftBarButtonItem = [[BTUIKBarButtonItem alloc] initWithTitle:BTDropInLocalizedString(CANCEL_ACTION) style:UIBarButtonItemStylePlain target:self action:@selector(cancelTapped)];
-    BTUIKBarButtonItem *addButton = [[BTUIKBarButtonItem alloc] initWithTitle:BTDropInLocalizedString(ADD_CARD_ACTION) style:UIBarButtonItemStylePlain target:self action:@selector(tokenizeCard)];
-    addButton.bold = YES;
-    self.navigationItem.rightBarButtonItem = addButton;
-    
-    self.navigationItem.rightBarButtonItem.enabled = NO;
-    self.navigationItem.rightBarButtonItem.accessibilityHint = BTDropInLocalizedString(REVIEW_AND_TRY_AGAIN);
     
     for (BTUIKFormField *formField in self.formFields) {
-        formField.text = @"";
+        if ([formField respondsToSelector:@selector(setText:)]) {
+            formField.text = @"";
+        }
         formField.hidden = YES;
     }
     // Using ivar so that setter is not called
@@ -476,16 +478,6 @@
         }
     }];
     return isFormValid;
-}
-
-- (void)updateSubmitButton {
-    if (!self.collapsed && [self isFormValid]) {
-        self.navigationItem.rightBarButtonItem.enabled = YES;
-        self.navigationItem.rightBarButtonItem.accessibilityHint = nil;
-    } else {
-        self.navigationItem.rightBarButtonItem.enabled = NO;
-        self.navigationItem.rightBarButtonItem.accessibilityHint = BTDropInLocalizedString(REVIEW_AND_TRY_AGAIN);
-    }
 }
 
 - (void)advanceFocusFromField:(BTUIKFormField *)currentField {
@@ -588,9 +580,9 @@
     spinner.activityIndicatorViewStyle = [BTUIKAppearance sharedInstance].activityIndicatorViewStyle;
     [spinner startAnimating];
 
-    UIBarButtonItem *addCardButton = self.navigationItem.rightBarButtonItem;
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:spinner];
     self.view.userInteractionEnabled = NO;
+    [self.addCardField setEnabled:NO];
     __block UINavigationController *navController = self.navigationController;
 
 #pragma clang diagnostic push
@@ -600,8 +592,9 @@
 #pragma clang diagnostic pop
         dispatch_async(dispatch_get_main_queue(), ^{
             self.view.userInteractionEnabled = YES;
+            [self.addCardField setEnabled:YES];
 
-            self.navigationItem.rightBarButtonItem = addCardButton;
+            self.navigationItem.rightBarButtonItem = nil;
 
             if (error != nil) {
                 NSString *message = BTDropInLocalizedString(REVIEW_AND_TRY_AGAIN);
@@ -634,6 +627,7 @@
         
         currentViewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:spinner];
         self.view.userInteractionEnabled = NO;
+        [self.addCardField setEnabled:NO];
     });
     
     [cardClient enrollCard:cardRequest completion:^(NSString * _Nullable enrollmentID, BOOL smsCodeRequired, NSError * _Nullable error) {
@@ -684,6 +678,7 @@
                 
                 enrollmentController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:spinner];
                 self.view.userInteractionEnabled = NO;
+                [self.addCardField setEnabled:NO];
             });
             
 #pragma clang diagnostic push
@@ -695,6 +690,7 @@
 #pragma clang diagnostic pop
                 dispatch_async(dispatch_get_main_queue(), ^{
                     self.view.userInteractionEnabled = YES;
+                    [self.addCardField setEnabled:YES];
                     enrollmentController.navigationItem.rightBarButtonItem = originalRightBarButtonItem;
                     if (error) {
                         [enrollmentController smsErrorHidden:NO];
@@ -770,8 +766,6 @@
 }
 
 - (void)formFieldDidChange:(BTUIKFormField *)formField {
-    [self updateSubmitButton];
-    
     // When focus moves from card number field, display the error state if the value in the field is invalid
     if (formField == self.cardNumberField && self.cardNumberField.state == BTUIKCardNumberFormFieldStateDefault) {
         [self cardNumberErrorHidden:self.cardNumberField.displayAsValid];
@@ -821,6 +815,22 @@
 
 - (BOOL)textFieldShouldReturn:(__unused UITextField *)textField {
     return YES;
+}
+
+#pragma mark SBTAddCardButtonFormFieldDelegate
+
+- (void)addCardFieldTapped:(SBTAddCardButtonFormField __unused *)field {
+    if ([self isFormValid]) {
+        [self tokenizeCard];
+    } else {
+        NSString *alertTitle = @"Attenzione";
+        NSString *alertMessage = @"Controlla di aver compilato tutti i campi correttamente";
+        UIAlertAction *alertAction = [UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:nil];
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:alertTitle message:alertMessage preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:alertAction];
+        
+        [self presentViewController:alertController animated:YES completion:nil];
+    }
 }
 
 @end

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -356,6 +356,7 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         [UIView animateWithDuration:0.15 delay:0.0 options:UIViewAnimationOptionAllowAnimatedContent|UIViewAnimationOptionBeginFromCurrentState animations:^{
             self.cardNumberHeader.hidden = !collapsed;
+            self.cardNumberFooter.hidden = !collapsed;
             self.cardholderNameField.hidden = (self.dropInRequest.cardholderNameSetting == BTFormFieldDisabled) || collapsed;
             self.expirationDateField.hidden = collapsed;
             self.securityCodeField.hidden = ![self.requiredFields containsObject:self.securityCodeField] || collapsed;

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -37,7 +37,7 @@
 - (BOOL)shouldDisplayVaultedNonceForRequest:(BTDropInRequest *)request config:(BTConfiguration *)configuration {
     if ([self isKindOfClass:BTCardNonce.class] && (request.cardDisabled || configuration.supportedCardTypes.count == 0)) {
         return NO;
-    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || !configuration.isPayPalEnabled)) {
+    } else if ([self isKindOfClass:BTPayPalAccountNonce.class] && (request.paypalDisabled || request.vaultedPaypalAccountsDisabled || !configuration.isPayPalEnabled)) {
         return NO;
     } else if ([self isKindOfClass:BTVenmoAccountNonce.class] && (request.venmoDisabled || !configuration.isVenmoEnabled)) {
         return NO;

--- a/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.h
+++ b/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.h
@@ -1,0 +1,22 @@
+// Copyright © 2019 Subito.it. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SBTAddCardButtonFormField;
+
+@protocol SBTAddCardButtonFormFieldDelegate <NSObject>
+
+- (void)addCardFieldTapped:(SBTAddCardButtonFormField *)field;
+
+@end
+
+@interface SBTAddCardButtonFormField : UIView
+
+@property (nonatomic, weak) id<SBTAddCardButtonFormFieldDelegate> delegate;
+@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.m
+++ b/Sources/BraintreeDropIn/Components/SBTAddCardButtonFormField.m
@@ -1,0 +1,82 @@
+// Copyright © 2019 Subito.it. All rights reserved.
+
+#import "SBTAddCardButtonFormField.h"
+#import "BTDropInLocalization_Internal.h"
+#import "BTUIKAppearance.h"
+
+@interface UIImage (Color)
+
++ (UIImage *)sbt_resizableImageWithColor:(UIColor *)color cornerRadius:(CGFloat)radius;
+
+@end
+
+@implementation UIImage (Color)
+
++ (UIImage *)sbt_resizableImageWithColor:(UIColor *)color cornerRadius:(CGFloat)radius {
+    CGSize size = CGSizeMake((radius * 2.0) + 1.0, (radius * 2.0) + 1.0);
+    CGRect rect = CGRectMake(0.0, 0.0, size.width, size.height);
+    
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *context) {
+        CGContextRef contextRef = context.CGContext;
+        CGContextSetFillColorWithColor(contextRef, color.CGColor);
+        CGContextAddPath(contextRef, [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:radius].CGPath);
+        CGContextFillPath(contextRef);
+    }];
+    
+    UIEdgeInsets capInsets = UIEdgeInsetsMake(radius, radius, radius, radius);
+    return [image resizableImageWithCapInsets:capInsets];
+}
+
+@end
+
+@interface SBTAddCardButtonFormField ()
+
+@property (nonatomic, strong) UIButton *addButton;
+
+@end
+
+@implementation SBTAddCardButtonFormField
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        UIImage *normalImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.tintColor cornerRadius:4.0];
+        UIImage *disabledImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.disabledColor cornerRadius:4.0];
+        UIImage *highlightedImage = [UIImage sbt_resizableImageWithColor:BTUIKAppearance.sharedInstance.highlightedTintColor cornerRadius:4.0];
+        
+        _addButton = [UIButton new];
+        _addButton.translatesAutoresizingMaskIntoConstraints = NO;
+        _addButton.titleLabel.font = [BTUIKAppearance.sharedInstance.headlineFont fontWithSize:UIFont.labelFontSize];
+        [_addButton setBackgroundImage:normalImage forState:UIControlStateNormal];
+        [_addButton setBackgroundImage:disabledImage forState:UIControlStateDisabled];
+        [_addButton setBackgroundImage:highlightedImage forState:UIControlStateHighlighted];
+        [_addButton setTitle:BTDropInLocalizedString(ADD_CARD_ACTION) forState:UIControlStateNormal];
+        [_addButton addTarget:self action:@selector(tapped) forControlEvents:UIControlEventTouchUpInside];
+        
+        [self addSubview:_addButton];
+        
+        NSLayoutConstraint *heightConstraint = [_addButton.heightAnchor constraintEqualToConstant:44.0];
+        heightConstraint.priority = UILayoutPriorityDefaultHigh;
+        
+        [NSLayoutConstraint activateConstraints:@[
+            heightConstraint,
+            [_addButton.topAnchor constraintEqualToAnchor:self.topAnchor],
+            [_addButton.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+            [_addButton.leadingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.leadingAnchor],
+            [_addButton.trailingAnchor constraintEqualToAnchor:self.layoutMarginsGuide.trailingAnchor]
+        ]];
+    }
+    return self;
+}
+
+- (void)setEnabled:(BOOL)enabled {
+    _enabled = enabled;
+    [self.addButton setEnabled:enabled];
+}
+
+- (void)tapped {
+    [self.delegate addCardFieldTapped:self];
+}
+
+@end
+

--- a/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
@@ -27,7 +27,7 @@
 
         self.label = [[UILabel alloc] init];
         [BTUIKAppearance styleLabelPrimary:self.label];
-        self.label.numberOfLines = 2;
+        self.label.numberOfLines = 0;
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
         [self.labelContainer addArrangedSubview:self.label];
 

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -32,6 +32,7 @@
     request.vaultManager = self.vaultManager;
     request.vaultCard = self.vaultCard;
     request.allowVaultCardOverride = self.allowVaultCardOverride;
+    request.vaultedPaypalAccountsDisabled = self.vaultedPaypalAccountsDisabled;
     return request;
 }
 

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -43,6 +43,9 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false. Set to true to hide all card logos for your account.
 @property (nonatomic, assign) BOOL cardLogosDisabled;
 
+/// Defaults to false. Set to true to hide vaulted PayPal accounts even if enabled for your account.
+@property (nonatomic, assign) BOOL vaultedPaypalAccountsDisabled;
+
 /// Optional: Enable 3DS verification and specify options and additional information.
 ///
 /// Note: To encourage 3DS 2.0 flows, set `billingAddress`, `amount`, `email`, `mobilePhone` for best results.

--- a/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
+++ b/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
@@ -40,7 +40,7 @@
 "MONTH_LABEL"                               = "Mese";
 
 "OTHER_LABEL"                               = "Altro";
-"CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito";
+"CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito (bancomat)";
 "RECENT_LABEL"                              = "Recenti";
 "SELECT_PAYMENT_LABEL"                      = "Metodo di pagamento";
 

--- a/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
+++ b/Sources/BraintreeDropIn/Resources/it.lproj/BTUI.strings
@@ -42,7 +42,7 @@
 "OTHER_LABEL"                               = "Altro";
 "CREDIT_OR_DEBIT_CARD_LABEL"                = "Carta di credito o di debito";
 "RECENT_LABEL"                              = "Recenti";
-"SELECT_PAYMENT_LABEL"                      = "Seleziona metodo di pagamento";
+"SELECT_PAYMENT_LABEL"                      = "Metodo di pagamento";
 
 "CONFIRM_ENROLLMENT_LABEL"                  = "Conferma registrazione";
 "CONFIRM_ACTION"                            = "Conferma";

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -52,6 +52,7 @@
     originalRequest.vaultManager = YES;
     originalRequest.vaultCard = NO;
     originalRequest.allowVaultCardOverride = YES;
+    originalRequest.vaultedPaypalAccountsDisabled = YES;
 
     BTDropInRequest *copiedRequest = [originalRequest copy];
     
@@ -67,6 +68,7 @@
     XCTAssertEqual(originalRequest.vaultManager, copiedRequest.vaultManager);
     XCTAssertEqual(originalRequest.vaultCard, copiedRequest.vaultCard);
     XCTAssertEqual(originalRequest.allowVaultCardOverride, copiedRequest.allowVaultCardOverride);
+    XCTAssertEqual(originalRequest.vaultedPaypalAccountsDisabled, copiedRequest.vaultedPaypalAccountsDisabled);
 
     XCTAssertEqual(originalRequest.threeDSecureRequest, copiedRequest.threeDSecureRequest);
     XCTAssertEqual(BTThreeDSecureVersion2, copiedRequest.threeDSecureRequest.versionRequested);


### PR DESCRIPTION
### Summary of changes

This PR applies the Subito-specific customizations introduced by https://github.com/Subito-it/braintree-ios-drop-in/pull/6 to version [`9.12.0`](https://github.com/braintree/braintree-ios-drop-in/releases/tag/9.12.0) of the Drop-In SDK.

The only customization that sees an additional change introduced by this PR is the replacement inside the card form of the bar button item with a confirm button displayed at the bottom of the form itself. Given that version [`9.9.0`](https://github.com/braintree/braintree-ios-drop-in/releases/tag/9.9.0) of the Drop-In SDK introduced a privacy label at the bottom of the form, commit 43e7255 adds a spacing after our add card button to avoid having them displayed too close together.

<br>
<details><summary>Preview (card form)</summary>
<p align="center">
<table>
<tr>
<td align="center"><b>Without custom spacing
<td align="center"><b>With custom spacing
<tr>
<td><img src="https://github.com/Subito-it/braintree-ios-drop-in/assets/3649282/e10f9941-ff75-445f-a823-b0fc1ffbdbc6" width="465">
<td><img src="https://github.com/Subito-it/braintree-ios-drop-in/assets/3649282/b062045f-b437-4456-9469-4e7f86592c40" width="465">
</table>
</p>
</details>